### PR TITLE
Added stonecutting recipes for slabs and stairs of all wood types

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Minecraft datapack to make slight tweaks, restore removed/unused content, and 
 - Leads can also be made with Honey Bottles instead of Slime Balls
 - Paper can now be crafted with Bamboo (3 Bamboo for 1 Paper)
 - Rabbit Hide now has a crafting recipe (9 Rotten Flesh, this allows 36 Rotten Flesh to be crafted into 1 Leather)
-- Saddles now have the [originally intended crafting recipe](https://minecraft.fandom.com/wiki/Java_Edition_removed_items#Horse_saddle) for "Horse Saddles"
+- Saddles now have the [originally intended crafting recipe](https://minecraft.wiki/w/Java_Edition_removed_items#Horse_saddle) for "Horse Saddles"
 - 4 String can now be crafted from a Wool Block (allowing for uncrafting Wool blocks from string)
 
 ### Items
@@ -57,7 +57,7 @@ A Minecraft datapack to make slight tweaks, restore removed/unused content, and 
 - Fix Leads breaking when unloaded (If they even still/ever did that?)
 - Implement Missing Potions/Splash Potions/Lingering Potions/Tipped Arrows
 - Implement Rubies
-- Both Blue Orchids and Dandelions give Saturation in the Suspicious Stew, instead make Blue Orchid give a [Health Boost](https://minecraft.gamepedia.com/Java_Edition_unused_features#Health_Boost)?
+- Both Blue Orchids and Dandelions give Saturation in the Suspicious Stew, instead make Blue Orchid give a [Health Boost](https://minecraft.wiki/w/Java_Edition_unused_features#Health_Boost)?
 - Make Wither Skulls less RNG based/more fun to collect?
 - Make Totem of Undying actually useful
   - [This suggestion is one way](https://www.reddit.com/r/minecraftsuggestions/comments/944co2/totems_of_undying_are_not_worth_getting_here_is/)
@@ -76,22 +76,22 @@ A Minecraft datapack to make slight tweaks, restore removed/unused content, and 
 ## Old changes which were implemented into official release (thus removed from datapack or plans)
 ### Blocks
 - Make Piston a Pickaxe tool block (instead of having no tool needed)
-  - [20w06a](https://minecraft.gamepedia.com/Java_Edition_20w06a) "Pickaxes are now more efficient on pistons"
+  - [20w06a](https://minecraft.wiki/w/Java_Edition_20w06a) "Pickaxes are now more efficient on pistons"
 
 ### Crafting
 - All Stair recipes now yield 8 Stairs instead of 4
-  - [19w04a](https://minecraft.gamepedia.com/19w04a) added Stonecutter which gives 1 Stair for 1 Block
+  - [19w04a](https://minecraft.wiki/w/Java_Edition_19w04a) added Stonecutter which gives 1 Stair for 1 Block
 - Smooth Stone now has a crafting recipe (2 Stone Slabs vertically)
-  - [1.14](https://minecraft.gamepedia.com/Java_Edition_1.14) added this block into survival
+  - [1.14](https://minecraft.wiki/w/Java_Edition_1.14) added this block into survival
 - Leads no longer require Slimeballs, instead need 5 String in the original shape
-  - [1.15](https://minecraft.gamepedia.com/Java_Edition_1.15) added Honey Blocks which is an alternative to Slime Blocks (albeit with slightly different properties) so instead of only requiring string added Honey Bottle as option along with Slime Ball.
+  - [1.15](https://minecraft.wiki/w/Java_Edition_1.15) added Honey Blocks which is an alternative to Slime Blocks (albeit with slightly different properties) so instead of only requiring string added Honey Bottle as option along with Slime Ball.
 
 ### Items
 - Add missing Leather Horse Armour (from Bedrock version)
 
 ### Loot tables
 - Village Blacksmith's chests now contain an *Old Mineshaft Map* (Mineshaft Explorer Map)
-  - [1.14](https://minecraft.gamepedia.com/1.14) changed villages, and removed the generic Blacksmith building
+  - [1.14](https://minecraft.wiki/w/1.14) changed villages, and removed the generic Blacksmith building
   - The map spawn was moved to the Cartographer's building instead
 ---
 ## Current wish-list/not possible list:

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/acacia_slab_from_acacia_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/acacia_slab_from_acacia_planks_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_acacia_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:acacia_planks"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:acacia_slab_from_acacia_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_acacia_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:acacia_slab_from_acacia_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/acacia_stairs_from_acacia_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/acacia_stairs_from_acacia_planks_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_acacia_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:acacia_planks"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:acacia_stairs_from_acacia_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_acacia_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:acacia_stairs_from_acacia_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/bamboo_mosaic_from_bamboo_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/bamboo_mosaic_from_bamboo_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_bamboo": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:bamboo"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:bamboo_mosaic_from_bamboo_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_bamboo"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:bamboo_mosaic_from_bamboo_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/bamboo_mosaic_slab_from_bamboo_mosaic_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/bamboo_mosaic_slab_from_bamboo_mosaic_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_bamboo_mosaic": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:bamboo_mosaic"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:bamboo_mosaic_slab_from_bamboo_mosaic_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_bamboo_mosaic"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:bamboo_mosaic_slab_from_bamboo_mosaic_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/bamboo_mosaic_slabs_from_bamboo_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/bamboo_mosaic_slabs_from_bamboo_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_bamboo": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:bamboo"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:bamboo_mosaic_slabs_from_bamboo_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_bamboo"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:bamboo_mosaic_slabs_from_bamboo_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/bamboo_mosaic_stairs_from_bamboo_mosaic_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/bamboo_mosaic_stairs_from_bamboo_mosaic_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_bamboo_mosaic": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:bamboo_mosaic"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:bamboo_mosaic_stairs_from_bamboo_mosaic_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_bamboo_mosaic"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:bamboo_mosaic_stairs_from_bamboo_mosaic_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/bamboo_mosaic_stairs_from_bamboo_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/bamboo_mosaic_stairs_from_bamboo_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_bamboo": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:bamboo"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:bamboo_mosaic_stairs_from_bamboo_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_bamboo"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:bamboo_mosaic_stairs_from_bamboo_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/bamboo_slab_from_bamboo_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/bamboo_slab_from_bamboo_planks_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_bamboo_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:bamboo_planks"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:bamboo_slab_from_bamboo_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_bamboo_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:bamboo_slab_from_bamboo_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/bamboo_stairs_from_bamboo_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/bamboo_stairs_from_bamboo_planks_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_bamboo_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:bamboo_planks"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:bamboo_stairs_from_bamboo_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_bamboo_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:bamboo_stairs_from_bamboo_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/birch_slab_from_birch_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/birch_slab_from_birch_planks_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_birch_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:birch_planks"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:birch_slab_from_birch_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_birch_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:birch_slab_from_birch_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/birch_stairs_from_birch_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/birch_stairs_from_birch_planks_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_birch_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:birch_planks"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:birch_stairs_from_birch_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_birch_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:birch_stairs_from_birch_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/cherry_slab_from_cherry_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/cherry_slab_from_cherry_planks_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_cherry_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:cherry_planks"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:cherry_slab_from_cherry_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_cherry_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:cherry_slab_from_cherry_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/cherry_stairs_from_cherry_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/cherry_stairs_from_cherry_planks_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_cherry_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:cherry_planks"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:cherry_stairs_from_cherry_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_cherry_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:cherry_stairs_from_cherry_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/crimson_slab_from_crimson_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/crimson_slab_from_crimson_planks_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_crimson_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:crimson_planks"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:crimson_slab_from_crimson_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_crimson_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:crimson_slab_from_crimson_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/crimson_stairs_from_crimson_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/crimson_stairs_from_crimson_planks_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_crimson_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:crimson_planks"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:crimson_stairs_from_crimson_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_crimson_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:crimson_stairs_from_crimson_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/dark_oak_slab_from_dark_oak_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/dark_oak_slab_from_dark_oak_planks_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_dark_oak_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:dark_oak_planks"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:dark_oak_slab_from_dark_oak_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_dark_oak_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:dark_oak_slab_from_dark_oak_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/dark_oak_stairs_from_dark_oak_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/dark_oak_stairs_from_dark_oak_planks_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_dark_oak_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:dark_oak_planks"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:dark_oak_stairs_from_dark_oak_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_dark_oak_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:dark_oak_stairs_from_dark_oak_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/jungle_slab_from_jungle_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/jungle_slab_from_jungle_planks_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_jungle_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:jungle_planks"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:jungle_slab_from_jungle_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_jungle_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:jungle_slab_from_jungle_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/jungle_stairs_from_jungle_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/jungle_stairs_from_jungle_planks_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_jungle_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:jungle_planks"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:jungle_stairs_from_jungle_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_jungle_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:jungle_stairs_from_jungle_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/mangrove_slab_from_mangrove_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/mangrove_slab_from_mangrove_planks_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_mangrove_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:mangrove_planks"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:mangrove_slab_from_mangrove_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_mangrove_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:mangrove_slab_from_mangrove_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/mangrove_stairs_from_mangrove_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/mangrove_stairs_from_mangrove_planks_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_mangrove_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:mangrove_planks"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:mangrove_stairs_from_mangrove_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_mangrove_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:mangrove_stairs_from_mangrove_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/oak_slab_from_oak_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/oak_slab_from_oak_planks_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_oak_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:oak_planks"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:oak_slab_from_oak_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_oak_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:oak_slab_from_oak_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/oak_stairs_from_oak_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/oak_stairs_from_oak_planks_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_oak_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:oak_planks"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:oak_stairs_from_oak_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_oak_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:oak_stairs_from_oak_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/spruce_slab_from_spruce_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/spruce_slab_from_spruce_planks_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_spruce_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:spruce_planks"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:spruce_slab_from_spruce_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_spruce_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:spruce_slab_from_spruce_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/spruce_stairs_from_spruce_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/spruce_stairs_from_spruce_planks_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_spruce_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:spruce_planks"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:spruce_stairs_from_spruce_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_spruce_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:spruce_stairs_from_spruce_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/warped_slab_from_warped_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/warped_slab_from_warped_planks_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_warped_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:warped_planks"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:warped_slab_from_warped_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_warped_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:warped_slab_from_warped_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/warped_stairs_from_warped_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/advancements/recipes/warped_stairs_from_warped_planks_stonecutting.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_warped_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:warped_planks"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:warped_stairs_from_warped_stonecutting"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_warped_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:warped_stairs_from_warped_stonecutting"
+    ]
+  }
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/acacia_slab_from_acacia_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/acacia_slab_from_acacia_planks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 2,
+  "ingredient": {
+    "item": "minecraft:acacia_planks"
+  },
+  "result": "minecraft:acacia_slab"
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/acacia_stairs_from_acacia_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/acacia_stairs_from_acacia_planks_stonecutting.json
@@ -2,7 +2,7 @@
   "type": "minecraft:stonecutting",
   "count": 1,
   "ingredient": {
-    "item": "minecraft:oak_planks"
+    "item": "minecraft:acacia_planks"
   },
-  "result": "minecraft:oak_stairs"
+  "result": "minecraft:acacia_stairs"
 }

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/bamboo_mosaic_from_bamboo_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/bamboo_mosaic_from_bamboo_stonecutting.json
@@ -2,7 +2,7 @@
   "type": "minecraft:stonecutting",
   "count": 1,
   "ingredient": {
-    "item": "minecraft:oak_planks"
+    "item": "minecraft:bamboo"
   },
-  "result": "minecraft:oak_stairs"
+  "result": "minecraft:bamboo_mosaic"
 }

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/bamboo_mosaic_slab_from_bamboo_mosaic_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/bamboo_mosaic_slab_from_bamboo_mosaic_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 2,
+  "ingredient": {
+    "item": "minecraft:bamboo_mosaic"
+  },
+  "result": "minecraft:bamboo_mosaic_slab"
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/bamboo_mosaic_slabs_from_bamboo_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/bamboo_mosaic_slabs_from_bamboo_stonecutting.json
@@ -2,7 +2,7 @@
   "type": "minecraft:stonecutting",
   "count": 1,
   "ingredient": {
-    "item": "minecraft:oak_planks"
+    "item": "minecraft:bamboo"
   },
-  "result": "minecraft:oak_stairs"
+  "result": "minecraft:bamboo_mosaic_slabs"
 }

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/bamboo_mosaic_stairs_from_bamboo_mosaic_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/bamboo_mosaic_stairs_from_bamboo_mosaic_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 1,
+  "ingredient": {
+    "item": "minecraft:bamboo_mosaic"
+  },
+  "result": "minecraft:bamboo_mosaic_stairs"
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/bamboo_mosaic_stairs_from_bamboo_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/bamboo_mosaic_stairs_from_bamboo_stonecutting.json
@@ -2,7 +2,7 @@
   "type": "minecraft:stonecutting",
   "count": 1,
   "ingredient": {
-    "item": "minecraft:oak_planks"
+    "item": "minecraft:bamboo"
   },
-  "result": "minecraft:oak_stairs"
+  "result": "minecraft:bamboo_mosaic_stairs"
 }

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/bamboo_slab_from_bamboo_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/bamboo_slab_from_bamboo_planks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 2,
+  "ingredient": {
+    "item": "minecraft:bamboo_planks"
+  },
+  "result": "minecraft:bamboo_slab"
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/bamboo_stairs_from_bamboo_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/bamboo_stairs_from_bamboo_planks_stonecutting.json
@@ -2,7 +2,7 @@
   "type": "minecraft:stonecutting",
   "count": 1,
   "ingredient": {
-    "item": "minecraft:oak_planks"
+    "item": "minecraft:bamboo_planks"
   },
-  "result": "minecraft:oak_stairs"
+  "result": "minecraft:bamboo_stairs"
 }

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/birch_slab_from_birch_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/birch_slab_from_birch_planks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 2,
+  "ingredient": {
+    "item": "minecraft:birch_planks"
+  },
+  "result": "minecraft:birch_slab"
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/birch_stairs_from_birch_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/birch_stairs_from_birch_planks_stonecutting.json
@@ -2,7 +2,7 @@
   "type": "minecraft:stonecutting",
   "count": 1,
   "ingredient": {
-    "item": "minecraft:oak_planks"
+    "item": "minecraft:birch_planks"
   },
-  "result": "minecraft:oak_stairs"
+  "result": "minecraft:birch_stairs"
 }

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/cherry_slab_from_cherry_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/cherry_slab_from_cherry_planks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 2,
+  "ingredient": {
+    "item": "minecraft:cherry_planks"
+  },
+  "result": "minecraft:cherry_slab"
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/cherry_stairs_from_cherry_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/cherry_stairs_from_cherry_planks_stonecutting.json
@@ -2,7 +2,7 @@
   "type": "minecraft:stonecutting",
   "count": 1,
   "ingredient": {
-    "item": "minecraft:oak_planks"
+    "item": "minecraft:cherry_planks"
   },
-  "result": "minecraft:oak_stairs"
+  "result": "minecraft:cherry_stairs"
 }

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/crimson_slab_from_crimson_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/crimson_slab_from_crimson_planks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 2,
+  "ingredient": {
+    "item": "minecraft:crimson_planks"
+  },
+  "result": "minecraft:crimson_slab"
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/crimson_stairs_from_crimson_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/crimson_stairs_from_crimson_planks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 1,
+  "ingredient": {
+    "item": "minecraft:crimson_planks"
+  },
+  "result": "minecraft:crimson_stairs"
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/dark_oak_slab_from_dark_oak_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/dark_oak_slab_from_dark_oak_planks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 2,
+  "ingredient": {
+    "item": "minecraft:dark_oak_planks"
+  },
+  "result": "minecraft:dark_oak_slab"
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/dark_oak_stairs_from_dark_oak_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/dark_oak_stairs_from_dark_oak_planks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 1,
+  "ingredient": {
+    "item": "minecraft:dark_oak_planks"
+  },
+  "result": "minecraft:dark_oak_stairs"
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/jungle_slab_from_jungle_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/jungle_slab_from_jungle_planks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 2,
+  "ingredient": {
+    "item": "minecraft:jungle_planks"
+  },
+  "result": "minecraft:jungle_slab"
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/jungle_stairs_from_jungle_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/jungle_stairs_from_jungle_planks_stonecutting.json
@@ -2,7 +2,7 @@
   "type": "minecraft:stonecutting",
   "count": 1,
   "ingredient": {
-    "item": "minecraft:oak_planks"
+    "item": "minecraft:jungle_planks"
   },
-  "result": "minecraft:oak_stairs"
+  "result": "minecraft:jungle_stairs"
 }

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/mangrove_slab_from_mangrove_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/mangrove_slab_from_mangrove_planks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 2,
+  "ingredient": {
+    "item": "minecraft:mangrove_planks"
+  },
+  "result": "minecraft:mangrove_slab"
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/mangrove_stairs_from_mangrove_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/mangrove_stairs_from_mangrove_planks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 1,
+  "ingredient": {
+    "item": "minecraft:mangrove_planks"
+  },
+  "result": "minecraft:mangrove_stairs"
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/oak_slab_from_oak_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/oak_slab_from_oak_planks_stonecutting.json
@@ -1,8 +1,8 @@
 {
   "type": "minecraft:stonecutting",
-  "count": 1,
+  "count": 2,
   "ingredient": {
     "item": "minecraft:oak_planks"
   },
-  "result": "minecraft:oak_stairs"
+  "result": "minecraft:oak_slab"
 }

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/spruce_slab_from_spruce_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/spruce_slab_from_spruce_planks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 2,
+  "ingredient": {
+    "item": "minecraft:spruce_planks"
+  },
+  "result": "minecraft:spruce_slab"
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/spruce_stairs_from_spruce_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/spruce_stairs_from_spruce_planks_stonecutting.json
@@ -2,7 +2,7 @@
   "type": "minecraft:stonecutting",
   "count": 1,
   "ingredient": {
-    "item": "minecraft:oak_planks"
+    "item": "minecraft:spruce_planks"
   },
-  "result": "minecraft:oak_stairs"
+  "result": "minecraft:spruce_stairs"
 }

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/warped_slab_from_warped_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/warped_slab_from_warped_planks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 2,
+  "ingredient": {
+    "item": "minecraft:warped_planks"
+  },
+  "result": "minecraft:warped_slab"
+}

--- a/vanilla_with_flake/data/vanilla_with_flake/recipes/warped_stairs_from_warped_planks_stonecutting.json
+++ b/vanilla_with_flake/data/vanilla_with_flake/recipes/warped_stairs_from_warped_planks_stonecutting.json
@@ -2,7 +2,7 @@
   "type": "minecraft:stonecutting",
   "count": 1,
   "ingredient": {
-    "item": "minecraft:oak_planks"
+    "item": "minecraft:warped_planks"
   },
-  "result": "minecraft:oak_stairs"
+  "result": "minecraft:warped_stairs"
 }


### PR DESCRIPTION
I hacked together some wonky Java code to generate recipes and advancements for slabs and stairs of all wood types, + some extra treatment for the oh so special bamboo. I have decided against adding recipes for log to planks crafting, because that didn't really seem neccessary to me, as you can just do that with inventory crafting. Furthermore it would just add to the file clutter in the datapack. I could still do that if there was demand for it tho.

Edit: Also replaced Gamepedia and Fandom links in README.md with their minecraft.wiki counterpart. Didn't mean to do that in this PR but apparently I have no idea how any of this works, oh well.

-Klimsalabim